### PR TITLE
fix: para and small font-size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -56,7 +56,7 @@ body {
 
 .body-text {
   font-weight: 400;
-  font-size: calc(0.75rem + 0.16vw);
+  font-size: 1rem;
   line-height: 1.33rem;
   letter-spacing: 0.03rem;
 }
@@ -70,7 +70,7 @@ body {
 
 .label-small {
   font-weight: 500;
-  font-size: calc(0.63rem + 0.2vw);
+  font-size: 0.83rem;
   line-height: 1.33rem;
   letter-spacing: 0.04rem;
 }


### PR DESCRIPTION
Fixed `body-text` font-size to `1rem` & `label-small` to `0.83rem` across all screen-sizes.